### PR TITLE
Fix a bug in TOTP editing causing a recursive error 

### DIFF
--- a/frontend/src/app/edit-totp/edit-totp.component.ts
+++ b/frontend/src/app/edit-totp/edit-totp.component.ts
@@ -148,12 +148,12 @@ export class EditTOTPComponent implements OnInit{
 
   generateCode(){
    this.code=this.totp(this.secret);
-  
    }
    
 
   checkSecret(){
     this.secretError = "";
+    this.secret = this.secret.replace(/\s/g, "");
     if(this.secret == ""){
       this.secretError = "Secret cannot be empty";
       return;


### PR DESCRIPTION
The error occured when the totp secret contains a whitespace