### PR TITLE
Reuse the original set interval for code computation and display update

### DIFF
--- a/frontend/src/app/edit-totp/edit-totp.component.ts
+++ b/frontend/src/app/edit-totp/edit-totp.component.ts
@@ -56,6 +56,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
   remainingTags:string[] = [];
   totp_code_expiration = 0;
   generating_next_totp_code = false;
+  totp_code_generation_interval:NodeJS.Timeout|undefined;
   constructor(
     private router: Router,
     private route : ActivatedRoute,
@@ -125,12 +126,13 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
       }
     }
     
-
-    this.compute_totp_expiration();
+    this.totp_code_generation_interval = setInterval(()=> { this.compute_totp_expiration() }, 100);
   }
 
   ngOnDestroy() {
-    cancelAnimationFrame(this.animationFrameId);
+    if(this.totp_code_generation_interval != undefined){
+      clearInterval(this.totp_code_generation_interval);
+    }
   }
 
   checkName(){
@@ -170,23 +172,14 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
 
 
   compute_totp_expiration(){
-
-    const update = () => {
       const now = Date.now();
       const remaining = this.totp_code_expiration - now;
       this.progress_bar_percent = (remaining/300);
-      console.log(remaining/100)
       if(remaining < 0 && !this.generating_next_totp_code) {
         this.generating_next_totp_code = true;
         this.generateCode();
         this.compute_totp_expiration();    // <-- redémarre le cycle
-        
-      } else {
-        this.animationFrameId = requestAnimationFrame(update);
-      }
-    };
-
-    update();
+      } 
   }
 
   generateCode(){

--- a/frontend/src/app/vault/vault.component.ts
+++ b/frontend/src/app/vault/vault.component.ts
@@ -65,6 +65,7 @@ export class VaultComponent implements OnInit, OnDestroy {
   progress_bar_percent=0;
   totp_code_expiration = 0;
   generating_next_totp_code = false;
+  totp_code_generation_interval:NodeJS.Timeout|undefined;
   constructor(
     public userService: UserService,
     private router: Router,
@@ -140,13 +141,15 @@ export class VaultComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    cancelAnimationFrame(this.animationFrameId);
+    if(this.totp_code_generation_interval != undefined){
+      clearInterval(this.totp_code_generation_interval);
+    }
   }
 
 
 
   startDisplayingCode(){
-    this.compute_totp_expiration();
+    this.totp_code_generation_interval = setInterval(()=> { this.compute_totp_expiration() }, 100);
        // setInterval(()=> { this.generateTime() }, 20);
        // setInterval(()=> { this.generateCode() }, 100);
   }
@@ -272,8 +275,6 @@ export class VaultComponent implements OnInit, OnDestroy {
 
 
   compute_totp_expiration(){
-
-    const update = () => {
       const now = Date.now();
       const remaining = this.totp_code_expiration - now;
       this.progress_bar_percent = (remaining/300);
@@ -281,12 +282,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         this.generating_next_totp_code = true;
         this.generateCode();
         this.compute_totp_expiration();
-      } else {
-        this.animationFrameId = requestAnimationFrame(update);
       }
-    };
-
-    update();
   }
 
   generateCode(){


### PR DESCRIPTION
This pull request refactors the TOTP (Time-based One-Time Password) code generation logic in both the `EditTOTPComponent` and `VaultComponent` to replace the use of `requestAnimationFrame` with `setInterval`. The changes aim to simplify the code and ensure proper cleanup of intervals during component destruction.

### Refactoring TOTP code generation:

* Replaced `requestAnimationFrame` with `setInterval` for periodic execution of the `compute_totp_expiration` method in both `EditTOTPComponent` and `VaultComponent`. This change simplifies the logic for updating TOTP expiration and progress bar percentage. (`frontend/src/app/edit-totp/edit-totp.component.ts`: [[1]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9L128-R135) [[2]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9L173-L189); `frontend/src/app/vault/vault.component.ts`: [[3]](diffhunk://#diff-a3c4502416c2dd6ea060a7dacd53a94185e359bd4bbcae996eda39482943d0efL143-R152) [[4]](diffhunk://#diff-a3c4502416c2dd6ea060a7dacd53a94185e359bd4bbcae996eda39482943d0efL275-L289)
* Introduced a new property `totp_code_generation_interval` in both components to store the `setInterval` reference, enabling proper cleanup. (`frontend/src/app/edit-totp/edit-totp.component.ts`: [[1]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9R59); `frontend/src/app/vault/vault.component.ts`: [[2]](diffhunk://#diff-a3c4502416c2dd6ea060a7dacd53a94185e359bd4bbcae996eda39482943d0efR68)

### Proper cleanup during component destruction:

* Added logic in the `ngOnDestroy` lifecycle hook to clear the interval using `clearInterval` if it is defined, ensuring no memory leaks or unintended behavior when the component is destroyed. (`frontend/src/app/edit-totp/edit-totp.component.ts`: [[1]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9L128-R135); `frontend/src/app/vault/vault.component.ts`: [[2]](diffhunk://#diff-a3c4502416c2dd6ea060a7dacd53a94185e359bd4bbcae996eda39482943d0efL143-R152)Keep the optimized way to generate code only when they expire

## Impact on performance 
This small but impactful optimization brings important computation saving while displaying TOTP codes (aka the most performed action) 

Savings measured (for compiled source, measured on a Macos M1, on Chromium, for the same account) : 
- Vault page : 
    - **CPU usage divided by 3.75**
    - **6 Mo of JS Heap saved (33% saved)**
    - **Computed frames (style and dom) per second : divided by 6 (from 60 computation/s to 10 computation/s)**
- Edit page : 
    - **CPU usage divided by 10**
    - **Not a notable specific save of JS Heap**
    - **Computed frames (style and dom) per second : divided by 6 (from 60 computation/s to 10 computation/s)**
    - 
