### PR TITLE
Several UI fixes

### DIFF
--- a/frontend/src/app/edit-totp/edit-totp.component.html
+++ b/frontend/src/app/edit-totp/edit-totp.component.html
@@ -68,14 +68,15 @@
             </div>
             <p class="help is-warning" *ngIf="uriError != ''">{{uriError | translate}}</p>
           </div>
-          <div class="field column is-two-thirds-mobile
+          <div class=" column is-two-thirds-mobile
           is-one-third-tablet
           is-one-third-desktop
           is-one-third-widescreen
-          is-one-third-fullhd mr-2 ml-2">
+          is-one-third-fullhd mr-2 ml-2 ">
             <label class="label">{{ 'totp.secret.add.label' | translate }}</label>
+            <div class="field has-addons">
             <div class="control has-icons-left has-icons-right">
-              <input class="input" type="text" placeholder="XXXXXXXXXXXXXXXX" name="secret" [(ngModel)]="secret"
+              <input class="input" type="{{isSecretVisible ? 'text' : 'password'}}" placeholder="XXXXXXXXXXXXXXXX" name="secret" [(ngModel)]="secret"
                 (change)="checkSecret()"
                 (keyup)="checkSecret()"
                 [ngClass]="{'is-danger':secretError != '', 'is-success' : secret != '' && secretError == '' }"
@@ -84,6 +85,13 @@
                 <fa-icon [icon]="faKey"></fa-icon>
               </span>
             </div>
+            <div class="control" >
+              <a class="button" (click)="isSecretVisible = !isSecretVisible">
+                <fa-icon [icon]="faEyeSlash" *ngIf="isSecretVisible" size="sm" ></fa-icon><fa-icon [icon]="faEye" *ngIf="!isSecretVisible" size="sm"></fa-icon>
+              </a>
+              
+            </div>
+          </div>
             <p class="help is-danger" *ngIf="secretError != ''">{{secretError | translate}}</p>
           </div>
         </div>

--- a/frontend/src/app/edit-totp/edit-totp.component.html
+++ b/frontend/src/app/edit-totp/edit-totp.component.html
@@ -112,7 +112,7 @@
         <div class="notification is-warning has-text-centered" *ngIf="this.userService.getIsVaultLocal()!">
           {{ 'totp.error.ro' | translate }}
         </div>
-        <div class="field p-5 is-flex is-justify-content-center">
+        <div class="field p-5 is-flex is-justify-content-center has-text-centered">
           
           <label class="checkbox">
             <input type="checkbox" name="favicon" [(ngModel)]="favicon" (change)="loadFavicon()" class="mr-3">

--- a/frontend/src/app/edit-totp/edit-totp.component.html
+++ b/frontend/src/app/edit-totp/edit-totp.component.html
@@ -34,12 +34,13 @@
     is-three-quarters-fullhd">
       <div class="is-flex is-justify-content-space-around is-flex-direction-column	">
         <div class="is-flex is-justify-content-space-around columns is-flex-wrap-wrap">
-          <div class="field column is-two-thirds-mobile
+          <div class="column is-two-thirds-mobile
         is-one-third-tablet
         is-one-third-desktop
         is-one-third-widescreen
         is-one-third-fullhd mr-2 ml-2">
             <label class="label">{{ 'name' | translate }}</label>
+            <div class="field has-addons">
             <div class="control has-icons-left has-icons-right">
               <input class="input" type="text" placeholder="GitHub" name="name" [(ngModel)]="name"
                 (keyup)="checkName()"
@@ -49,14 +50,21 @@
                 <fa-icon [icon]="faPassport"></fa-icon>
               </span>
             </div>
+            <div class="control ">
+              <a class="button" (click)="this.name= '';">
+                  <fa-icon [icon]="faXmark"></fa-icon>
+              </a>
+            </div>
+            </div>
             <p class="help is-danger" *ngIf="nameError != ''">{{nameError | translate}}</p>
           </div>
-          <div class="field column is-two-thirds-mobile
+          <div class="column is-two-thirds-mobile
         is-one-third-tablet
         is-one-third-desktop
         is-one-third-widescreen
         is-one-third-fullhd mr-2 ml-2">
             <label class="label">{{ 'totp.uri.title' | translate}}</label>
+            <div class="field has-addons">
             <div class="control has-icons-left has-icons-right">
               <input class="input" type="text" placeholder="https://github.com" name="uri" [(ngModel)]="uri"
                 (change)="checkURI()"
@@ -65,6 +73,12 @@
               <span class="icon is-small is-left">
                 <fa-icon [icon]="faGlobe"></fa-icon>
               </span>
+            </div>
+            <div class="control ">
+              <a class="button" (click)="this.uri= '';">
+                  <fa-icon [icon]="faXmark"></fa-icon>
+              </a>
+            </div>
             </div>
             <p class="help is-warning" *ngIf="uriError != ''">{{uriError | translate}}</p>
           </div>

--- a/frontend/src/app/edit-totp/edit-totp.component.ts
+++ b/frontend/src/app/edit-totp/edit-totp.component.ts
@@ -127,7 +127,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
     }
     
     this.totp_code_generation_interval = setInterval(()=> { this.compute_totp_expiration() }, 100);
-    this.generateCode();
+    
   }
 
   ngOnDestroy() {
@@ -289,6 +289,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
             this.uuid = this.secret_uuid!;
             this.name = property.get("name")!;
             this.secret = property.get("secret")!;
+            this.generateCode();
             this.color = property.get("color")!;
             this.translate.get("blue").subscribe((blue: string) => {
             switch(this.color){

--- a/frontend/src/app/edit-totp/edit-totp.component.ts
+++ b/frontend/src/app/edit-totp/edit-totp.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { UserService } from '../common/User/user.service';
 import { HttpClient } from '@angular/common/http';
-import { faChevronCircleLeft, faGlobe, faKey, faCircleQuestion, faPassport, faPlus, faCheck, faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import { faChevronCircleLeft, faGlobe, faKey, faCircleQuestion, faPassport, faPlus, faCheck, faCircleNotch, faEyeSlash, faEye } from '@fortawesome/free-solid-svg-icons';
 import { Utils  } from '../common/Utils/utils';
 
 import { Crypto } from '../common/Crypto/crypto';
@@ -28,6 +28,8 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
   faCircleNotch = faCircleNotch;
   faPlus = faPlus;
   faCheck = faCheck;
+  faEyeSlash=faEyeSlash;
+  faEye=faEye;
   faCircleQuestion = faCircleQuestion;
   faviconURL = "";
   name = "";
@@ -54,6 +56,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
   isEditing = false; // true if editing, false if adding
   isSaving = false;
   remainingTags:string[] = [];
+  isSecretVisible=true;
   totp_code_expiration = 0;
   generating_next_totp_code = false;
   totp_code_generation_interval:NodeJS.Timeout|undefined;
@@ -99,6 +102,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
         
     } else {
       this.isEditing = true;
+      this.isSecretVisible = false;
       console.log("is editing")
       if(!this.userService.getIsVaultLocal()){
         this.getSecretTOTP()

--- a/frontend/src/app/edit-totp/edit-totp.component.ts
+++ b/frontend/src/app/edit-totp/edit-totp.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { UserService } from '../common/User/user.service';
 import { HttpClient } from '@angular/common/http';
-import { faChevronCircleLeft, faGlobe, faKey, faCircleQuestion, faPassport, faPlus, faCheck, faCircleNotch, faEyeSlash, faEye } from '@fortawesome/free-solid-svg-icons';
+import { faChevronCircleLeft, faGlobe, faKey, faCircleQuestion, faPassport, faPlus, faCheck, faCircleNotch, faEyeSlash, faEye, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { Utils  } from '../common/Utils/utils';
 
 import { Crypto } from '../common/Crypto/crypto';
@@ -29,6 +29,7 @@ export class EditTOTPComponent implements OnInit, OnDestroy{
   faPlus = faPlus;
   faCheck = faCheck;
   faEyeSlash=faEyeSlash;
+  faXmark=faXmark;
   faEye=faEye;
   faCircleQuestion = faCircleQuestion;
   faviconURL = "";


### PR DESCRIPTION
This pull request enhances the `EditTOTPComponent` in the frontend by improving user experience with new UI elements, better state management, and minor refactoring. Key changes include the addition of clear buttons for input fields, a toggle for password visibility, and adjustments to the component's logic to initialize and manage state more effectively.

### UI Enhancements:
* Added clear buttons for the `name` and `uri` input fields, allowing users to reset these fields with a single click. (`frontend/src/app/edit-totp/edit-totp.component.html`: [[1]](diffhunk://#diff-ae71a36447214ec3151f8e35b8820eb75256ea87a35bd1955b0ae7e1919f7fa1R53-R67) [[2]](diffhunk://#diff-ae71a36447214ec3151f8e35b8820eb75256ea87a35bd1955b0ae7e1919f7fa1R77-R115)
* Introduced a toggle button for the `secret` field to switch between text and password visibility, improving usability for sensitive data. (`frontend/src/app/edit-totp/edit-totp.component.html`: [frontend/src/app/edit-totp/edit-totp.component.htmlR77-R115](diffhunk://#diff-ae71a36447214ec3151f8e35b8820eb75256ea87a35bd1955b0ae7e1919f7fa1R77-R115))

### State Management Improvements:
* Added a new `isSecretVisible` property to manage the visibility state of the `secret` field and initialized it appropriately when editing an existing TOTP entry. (`frontend/src/app/edit-totp/edit-totp.component.ts`: [[1]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9R60) [[2]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9R106)
* Moved the `generateCode()` call to ensure it is executed only when the secret is fetched, improving initialization logic. (`frontend/src/app/edit-totp/edit-totp.component.ts`: [[1]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9L130-R135) [[2]](diffhunk://#diff-e70dedec0ff545404a3f2a3685729a60a38410fd386665e9433c52dac8ef2bd9R297)
